### PR TITLE
fix: upgrade Highlight.run packages for Next.js 15 compatibility

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -10,10 +10,27 @@ jobs:
     environment: e2e # this is where environment variables are set
     timeout-minutes: 60
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_PASSWORD: test
+          POSTGRES_USER: test
+          POSTGRES_DB: testdb
+        ports:
+          - 5433:5432
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     env:
       APP_ENV: E2E #the actual build step needs this, not the runing of the tests or migrations
     steps:
       - uses: actions/checkout@v4
+      
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          
       - uses: actions/setup-node@v4
         with:
           node-version: lts/*
@@ -36,14 +53,20 @@ jobs:
 
       - name: Create .env.e2e
         run: |
-          echo "APP_ENV=${{ secrets.APP_ENV }}" > .env.e2e
-          echo "DB_URL=${{ secrets.DB_URL }}" >> .env.e2e
-          echo "MIGRATIONS_PATH=${{ secrets.MIGRATIONS_PATH }}" >> .env.e2e
-          echo "E2E_URL=${{ secrets.E2E_URL }}" >> .env.e2e
+          echo "APP_ENV=E2E" > .env.e2e
+          echo "DB_URL=postgresql://test:test@localhost:5433/testdb" >> .env.e2e
+          echo "MIGRATIONS_PATH=./drizzle/e2e-migrations" >> .env.e2e
+          echo "E2E_URL=http://localhost:3001" >> .env.e2e
           chmod 600 .env.e2e
 
+      - name: Run database migrations
+        run: npm run e2e:migrate
+
+      - name: Build application
+        run: npm run build:e2e
+
       - name: Run E2E tests
-        run: npm run test:e2e
+        run: npm run _test:e2e:with-app
 
       - uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "name": "next-drizzle-tailwind-auth",
       "version": "0.1.0",
       "dependencies": {
-        "@highlight-run/next": "^7.9.23",
-        "@highlight-run/node": "^3.12.7",
+        "@highlight-run/next": "^7.9.38",
+        "@highlight-run/node": "^3.12.22",
         "@hookform/resolvers": "^5.0.1",
         "@neondatabase/serverless": "^1.0.0",
         "@radix-ui/react-slot": "^1.2.0",
@@ -1159,15 +1159,15 @@
       }
     },
     "node_modules/@highlight-run/next": {
-      "version": "7.9.24",
-      "resolved": "https://registry.npmjs.org/@highlight-run/next/-/next-7.9.24.tgz",
-      "integrity": "sha512-l86pliIwME9i6BkBNggSKl2JisiWQ7DdY+AQXXSMoiguvR04pImPzyzasSMWzXuIbwlN3XubpbM6BT3PzK1A/g==",
+      "version": "7.9.38",
+      "resolved": "https://registry.npmjs.org/@highlight-run/next/-/next-7.9.38.tgz",
+      "integrity": "sha512-wjqvtnb18e/fEzjqPCQBtOeM03+7x7dk6Jdah7u7VOTbtdz6T4LUw2UATLkN+zIr+tlbMBPD065eG8aEQ9mDwg==",
       "dependencies": {
         "@highlight-run/cloudflare": "3.1.0",
-        "@highlight-run/node": "3.12.8",
-        "@highlight-run/react": "19.0.12",
+        "@highlight-run/node": "3.12.22",
+        "@highlight-run/react": "21.0.0",
         "@highlight-run/sourcemap-uploader": "0.6.3",
-        "highlight.run": "9.18.12",
+        "highlight.run": "9.20.0",
         "js-cookie": "^3.0.5",
         "next": ">=13"
       },
@@ -1177,21 +1177,21 @@
       }
     },
     "node_modules/@highlight-run/node": {
-      "version": "3.12.8",
-      "resolved": "https://registry.npmjs.org/@highlight-run/node/-/node-3.12.8.tgz",
-      "integrity": "sha512-blOT33EAJrza774YkKs/5zHevSKl2JNUMBPt9VGp/X/aJwFVzTQHIJseLrsWVoAmrAnWh2FtnOhCfuCn9DPMtA==",
+      "version": "3.12.22",
+      "resolved": "https://registry.npmjs.org/@highlight-run/node/-/node-3.12.22.tgz",
+      "integrity": "sha512-ujqFuC/+3mGiBeY+Fi59ChLnS2AvAz59+idMyt44Lb2vQVyWR/8SfLRzYxFzcLpnZqF8v04sCjqUtKNe+ssWfw==",
       "dependencies": {
         "@prisma/instrumentation": ">=5.0.0",
-        "highlight.run": "9.18.12",
+        "highlight.run": "9.20.0",
         "require-in-the-middle": "^7.4.0"
       }
     },
     "node_modules/@highlight-run/react": {
-      "version": "19.0.12",
-      "resolved": "https://registry.npmjs.org/@highlight-run/react/-/react-19.0.12.tgz",
-      "integrity": "sha512-cIUP2ZjG6KdPh8TzM4TDB5iMiH6PUTgrNtv7zB69/9bcM/AyH08iJYDALr+d7wy0pQOHHrYv3jWryEnVMGWeng==",
+      "version": "21.0.0",
+      "resolved": "https://registry.npmjs.org/@highlight-run/react/-/react-21.0.0.tgz",
+      "integrity": "sha512-bNfMMTbCtg+xXqVxAluovHWdJXWmgeHQWVcJsFMjp8INAYY9RaYrJ98Xf0Fr/PLru8udPE7396qPafAdN3O2/w==",
       "peerDependencies": {
-        "highlight.run": "9.18.12",
+        "highlight.run": "9.20.0",
         "react": ">=16",
         "react-dom": ">=16"
       }
@@ -2076,33 +2076,30 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation": {
-      "version": "0.57.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.57.2.tgz",
-      "integrity": "sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==",
+      "version": "0.203.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.203.0.tgz",
+      "integrity": "sha512-ke1qyM+3AK2zPuBPb6Hk/GCsc5ewbLvPNkEuELx/JmANeEp6ZjnZ+wypPAJSucTw0wvCGrUaibDSdcrGFoWxKQ==",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.57.2",
-        "@types/shimmer": "^1.2.0",
+        "@opentelemetry/api-logs": "0.203.0",
         "import-in-the-middle": "^1.8.1",
-        "require-in-the-middle": "^7.1.1",
-        "semver": "^7.5.2",
-        "shimmer": "^1.2.1"
+        "require-in-the-middle": "^7.1.1"
       },
       "engines": {
-        "node": ">=14"
+        "node": "^18.19.0 || >=20.6.0"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
       }
     },
     "node_modules/@opentelemetry/instrumentation/node_modules/@opentelemetry/api-logs": {
-      "version": "0.57.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.57.2.tgz",
-      "integrity": "sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==",
+      "version": "0.203.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.203.0.tgz",
+      "integrity": "sha512-9B9RU0H7Ya1Dx/Rkyc4stuBZSGVQF27WigitInx2QQoj6KUpEFYPKoWjdFTunJYxmXmh17HeBvbMa1EhGyPmqQ==",
       "dependencies": {
         "@opentelemetry/api": "^1.3.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=8.0.0"
       }
     },
     "node_modules/@opentelemetry/otlp-exporter-base": {
@@ -2384,11 +2381,11 @@
       }
     },
     "node_modules/@prisma/instrumentation": {
-      "version": "6.8.2",
-      "resolved": "https://registry.npmjs.org/@prisma/instrumentation/-/instrumentation-6.8.2.tgz",
-      "integrity": "sha512-5NCTbZjw7a+WIZ/ey6G8SY+YKcyM2zBF0hOT1muvqC9TbVtTCr5Qv3RL/2iNDOzLUHEvo4I1uEfioyfuNOGK8Q==",
+      "version": "6.16.2",
+      "resolved": "https://registry.npmjs.org/@prisma/instrumentation/-/instrumentation-6.16.2.tgz",
+      "integrity": "sha512-uWOPZVBLorJgGTfNajWydrCwtWGgaJwaUNa82u+wVTX5i5gTSmNERm97+aIfz1EHbAbEi710CneQolGlBN8w4g==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.52.0 || ^0.53.0 || ^0.54.0 || ^0.55.0 || ^0.56.0 || ^0.57.0"
+        "@opentelemetry/instrumentation": "^0.52.0 || ^0.53.0 || ^0.54.0 || ^0.55.0 || ^0.56.0 || ^0.57.0 || ^0.203.0"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.8"
@@ -4586,11 +4583,6 @@
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
-    },
-    "node_modules/@types/shimmer": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.2.0.tgz",
-      "integrity": "sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg=="
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",
@@ -7419,11 +7411,12 @@
       }
     },
     "node_modules/highlight.run": {
-      "version": "9.18.12",
-      "resolved": "https://registry.npmjs.org/highlight.run/-/highlight.run-9.18.12.tgz",
-      "integrity": "sha512-+1AtMAk76AtRy1txZUS4c5HHdsvGPVeaOEAy36WZjCRDmuBVbe4qftBC4GUm7Nol4xq4RfFUxR34RwilbBGunw==",
+      "version": "9.20.0",
+      "resolved": "https://registry.npmjs.org/highlight.run/-/highlight.run-9.20.0.tgz",
+      "integrity": "sha512-DJTPPWG6plAW2R8tBa6zU5g5qWpPwhqtR9izOe+PpZnLr/2/zGgHr2d+cay7Ivx82FgHdu1d4lZbx2ORy80NvA==",
       "dependencies": {
-        "@launchdarkly/js-client-sdk": "^0.6.0"
+        "@launchdarkly/js-client-sdk": "^0.6.0",
+        "imurmurhash": "^0.1.4"
       }
     },
     "node_modules/hosted-git-info": {
@@ -7500,9 +7493,9 @@
       }
     },
     "node_modules/import-in-the-middle": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.14.0.tgz",
-      "integrity": "sha512-g5zLT0HaztRJWysayWYiUq/7E5H825QIiecMD2pI5QO7Wzr847l6GDvPvmZaDIdrDtS2w7qRczywxiK6SL5vRw==",
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.14.3.tgz",
+      "integrity": "sha512-ajmxBgfBxVO9GWzD79xktBvMk2kTrqsXPKV0jg5pcwwcFpuLNSHwcPPvp4cgCQshlWz2ivgu5JiuRgDh+2ixGQ==",
       "dependencies": {
         "acorn": "^8.14.0",
         "acorn-import-attributes": "^1.9.5",
@@ -7514,7 +7507,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
-      "dev": true,
       "engines": {
         "node": ">=0.8.19"
       }
@@ -10142,6 +10134,7 @@
       "version": "7.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
       "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "devOptional": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -10268,11 +10261,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/shimmer": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
-      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
     },
     "node_modules/side-channel": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
     "e2e:test:logged-in": "npx wait-on http://localhost:3001 && dotenv -e .env.e2e -- playwright test --project=logged-in"
   },
   "dependencies": {
-    "@highlight-run/next": "^7.9.23",
-    "@highlight-run/node": "^3.12.7",
+    "@highlight-run/next": "^7.9.38",
+    "@highlight-run/node": "^3.12.22",
     "@hookform/resolvers": "^5.0.1",
     "@neondatabase/serverless": "^1.0.0",
     "@radix-ui/react-slot": "^1.2.0",


### PR DESCRIPTION
- Upgrade @highlight-run/next from 7.9.23 to 7.9.38
- Upgrade @highlight-run/node from 3.12.7 to 3.12.22
- Add Docker Hub authentication to GitHub Actions e2e tests
- Configure postgres service with health checks for CI
- Update e2e test workflow to avoid Docker Hub auth issues

This resolves the 'Cannot set property url' error that prevents API routes from working with Next.js 15 and Highlight.run integration.